### PR TITLE
Add citation for 2025 CinC ECG monitoring publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,19 @@
     </div>
     <h2>Publications</h2>
     <div class="publication">
-        <img src="overview.png" alt="Publication Overview Figure, Guidance steps 1-5, visualizing mean surface, variance surface, and acquisition function surface values.">
+        <img src="overview.png" alt="Publication Overview Figure showing guidance steps one through five and surfaces for mean, variance, and acquisition function values.">
         <div>
-            <strong><a href="https://doi.org/10.1016/j.compbiomed.2024.109201">BOATMAP: Bayesian Optimization Active Targeting for Monomorphic Arrhythmia Pace-mapping<a></strong><br>
-            <em>Meisenzahl, C., Gillette, K., Prassl, A. J., Plank, G., Sapp, J. L., & Wang, L</em><br>
+            <strong><a href="https://doi.org/10.1016/j.compbiomed.2024.109201">BOATMAP: Bayesian Optimization Active Targeting for Monomorphic Arrhythmia Pace-mapping</a></strong><br>
+            <em>Meisenzahl, C., Gillette, K., Prassl, A. J., Plank, G., Sapp, J. L., &amp; Wang, L.</em><br>
             <p>An active learning approach to pace-mapping, providing interpretable guidance.</p>
+        </div>
+    </div>
+
+    <div class="publication">
+        <div>
+            <strong><a href="380_CinCFinalPDF.pdf">Extended Single-Lead ECG Monitoring for AF Detection Using Deep Learning</a></strong><br>
+            <em>Casey Meisenzahl, Xiaojuan Xia, Kimberly Hsu, Homayra Tabassum, Dillon J Dzikowicz, R Tsouri, Burr Hall, Ryan Missel, Paras Jain, Kpangni Koua, &amp; Linwei Wang.</em><br>
+            <span>Computing in Cardiology, São Paulo, Brazil, September 2025.</span>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add the Extended Single-Lead ECG Monitoring for AF Detection Using Deep Learning citation and link to the local PDF
- tidy the existing BOATMAP publication entry with corrected link formatting and improved alt text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eed830b574832e89f970cde7a63808